### PR TITLE
Improve active profiles API

### DIFF
--- a/src/ActiveProfilesBuilder.php
+++ b/src/ActiveProfilesBuilder.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace Cspray\AnnotatedContainer;
+
+use InvalidArgumentException;
+
+final class ActiveProfilesBuilder {
+
+    private array $profiles = [];
+
+    private function __construct() {}
+
+    public static function hasDefault() : self {
+        return new self();
+    }
+
+    public function add(string... $profiles) : self {
+        if (empty($profiles)) {
+            throw new InvalidArgumentException('When adding a profile at least 1 value must be provided.');
+        } else if (in_array('default', $profiles)) {
+            throw new InvalidArgumentException("The 'default' profile is already active and should not be added explicitly.");
+        } else if (!empty($dupes = array_intersect($this->profiles, $profiles))) {
+            throw new InvalidArgumentException(sprintf(
+                "The '%s' %s already active and cannot be added again.",
+                join("', '", $dupes),
+                count($dupes) === 1 ? 'profile is' : 'profiles are'
+            ));
+        }
+        $instance = clone $this;
+        $instance->profiles = [...$this->profiles, ...$profiles];
+        return $instance;
+    }
+
+    public function addIf(string $profile, callable $decider) : self {
+        if ($profile === 'default') {
+            throw new InvalidArgumentException("The 'default' profile is already active and should not be added explicitly.");
+        }
+        $instance = clone $this;
+        if ($decider()) {
+            if (in_array($profile, $this->profiles)) {
+                throw new InvalidArgumentException(sprintf(
+                    "The '%s' profile is already active and cannot be added again.",
+                    $profile
+                ));
+            }
+            $instance->profiles[] = $profile;
+        }
+        return $instance;
+    }
+
+    public function addAllIf(array $profiles, callable $decider) : self {
+        if (in_array('default', $profiles)) {
+            throw new InvalidArgumentException("The 'default' profile is already active and should not be added explicitly.");
+        }
+        $instance = clone $this;
+        if ($decider()) {
+            if (!empty($dupes = array_intersect($this->profiles, $profiles))) {
+                throw new InvalidArgumentException(sprintf(
+                    "The '%s' %s already active and cannot be added again.",
+                    join("', '", $dupes),
+                    count($dupes) === 1 ? 'profile is' : 'profiles are'
+                ));
+            }
+            $instance->profiles = [...$this->profiles, ...$profiles];
+        }
+        return $instance;
+    }
+
+    public function build() : array {
+        return ['default', ...$this->profiles];
+    }
+
+}

--- a/src/ActiveProfilesParser.php
+++ b/src/ActiveProfilesParser.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Cspray\AnnotatedContainer;
+
+interface ActiveProfilesParser {
+
+    public function parse(string $profiles) : array;
+
+}

--- a/src/CsvActiveProfilesParser.php
+++ b/src/CsvActiveProfilesParser.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Cspray\AnnotatedContainer;
+
+class CsvActiveProfilesParser implements ActiveProfilesParser {
+
+    public function parse(string $profiles) : array {
+        if (empty($profiles)) {
+            throw new \InvalidArgumentException('The profiles to parse cannot be an empty string.');
+        }
+        $parsedProfiles = preg_split('/\s*,\s*/', trim($profiles), flags: PREG_SPLIT_NO_EMPTY);
+        if (empty($parsedProfiles)) {
+            throw new \InvalidArgumentException(sprintf("The profile string '%s' results in no valid profiles.", $profiles));
+        }
+        return $parsedProfiles;
+    }
+
+}

--- a/test/ActiveProfilesBuilderTest.php
+++ b/test/ActiveProfilesBuilderTest.php
@@ -1,0 +1,169 @@
+<?php declare(strict_types=1);
+
+namespace Cspray\AnnotatedContainer;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class ActiveProfilesBuilderTest extends TestCase {
+
+    public function testAddNoProfilesThrowsException() : void {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('When adding a profile at least 1 value must be provided.');
+
+        ActiveProfilesBuilder::hasDefault()->add()->build();
+    }
+
+    public function testAddDefaultProfileExplicitlyThrowsException() : void {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The \'default\' profile is already active and should not be added explicitly.');
+
+        ActiveProfilesBuilder::hasDefault()->add('default');
+    }
+
+    public function testAddSingleDuplicateProfileThrowsException() : void {
+        $builder = ActiveProfilesBuilder::hasDefault()->add('foo', 'bar', 'baz');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("The 'baz' profile is already active and cannot be added again.");
+        $builder->add('qux', 'baz');
+    }
+
+    public function testAddMultipleDuplicateProfileThrowsException() {
+        $builder = ActiveProfilesBuilder::hasDefault()->add('foo', 'bar', 'baz');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("The 'foo', 'baz' profiles are already active and cannot be added again.");
+        $builder->add('qux', 'baz', 'foo');
+    }
+
+    public function testAddIfDefaultProfileExplicitlyThrowsException() : void {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The \'default\' profile is already active and should not be added explicitly.');
+
+        ActiveProfilesBuilder::hasDefault()->addIf('default', fn() => true);
+    }
+
+    public function testAddIfTrueDuplicateProfileThrowsException() : void {
+        $builder = ActiveProfilesBuilder::hasDefault()->add('foo', 'bar', 'baz');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("The 'baz' profile is already active and cannot be added again.");
+        $builder->addIf('baz', fn() => true);
+    }
+
+    public function testAddAllIfDefaultProfileExplicitlyThrowsException() : void {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The \'default\' profile is already active and should not be added explicitly.');
+        ActiveProfilesBuilder::hasDefault()->addAllIf(['default'], fn() => false);
+    }
+
+    public function testAddAllIfTrueSingleDuplicateProfileThrowsException() : void {
+        $builder = ActiveProfilesBuilder::hasDefault()->add('foo', 'bar', 'baz');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("The 'baz' profile is already active and cannot be added again.");
+        $builder->addAllIf(['baz', 'qux'], fn() => true);
+    }
+
+    public function testAddAllIfTrueMultipleDuplicateProfileThrowsException() : void {
+        $builder = ActiveProfilesBuilder::hasDefault()->add('foo', 'qux', 'bar');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("The 'foo', 'bar' profiles are already active and cannot be added again.");
+        $builder->addAllIf(['foo', 'baz', 'bar'], fn() => true);
+    }
+
+    public function testAddReturnsDifferentInstance() : void {
+        $builder = ActiveProfilesBuilder::hasDefault();
+        $addBuilder = $builder->add('foo');
+
+        $this->assertNotSame($builder, $addBuilder);
+    }
+
+    public function testAddIfReturnsDifferentInstance() : void {
+        $builder = ActiveProfilesBuilder::hasDefault();
+        $addIfBuilder = $builder->addIf('profile', fn() => true);
+
+        $this->assertNotSame($builder, $addIfBuilder);
+    }
+
+    public function testAddAllIfReturnsDifferentInstance() : void {
+        $builder = ActiveProfilesBuilder::hasDefault();
+        $addAllIfBuilder = $builder->addAllIf(['foo', 'bar'], fn() => false);
+
+        $this->assertNotSame($builder, $addAllIfBuilder);
+    }
+
+    public function testBuildHasDefault() : void {
+        $actual = ActiveProfilesBuilder::hasDefault()->build();
+        $expected = ['default'];
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function addProvider() : array {
+        return [
+            [['foo']],
+            [['foo', 'bar']],
+            [['foo', 'bar', 'baz']]
+        ];
+    }
+
+    /**
+     * @dataProvider addProvider
+     */
+    public function testAddWithProfilesBuild(array $profiles) : void {
+        $actual = ActiveProfilesBuilder::hasDefault()->add(...$profiles)->build();
+        $expected = ['default', ...$profiles];
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testAddIfTrueInList() : void {
+        $actual = ActiveProfilesBuilder::hasDefault()
+            ->addIf('foo', fn() => true)
+            ->build();
+        $expected = ['default', 'foo'];
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testAddIfFalseNotInList() : void {
+        $actual = ActiveProfilesBuilder::hasDefault()
+            ->addIf('foo', fn() => false)
+            ->build();
+        $expected = ['default'];
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testAddIfFalseDuplicateProfileDoesNotThrowException() {
+        $actual = ActiveProfilesBuilder::hasDefault()
+            ->add('foo', 'baz')
+            ->addIf('baz', fn() => false)
+            ->build();
+        $expected = ['default', 'foo', 'baz'];
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testAddAllIfTrueInList() : void {
+        $actual = ActiveProfilesBuilder::hasDefault()
+            ->addAllIf(['foo', 'bar'], fn() => true)
+            ->build();
+        $expected = ['default', 'foo', 'bar'];
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testAddAllIfFalseNotInList() : void {
+        $actual = ActiveProfilesBuilder::hasDefault()
+            ->addAllIf(['foo', 'bar'], fn() => false)
+            ->build();
+        $expected = ['default'];
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testAddAllIfFalseDuplicateProfileDoesNotThrowException() : void {
+        $actual = ActiveProfilesBuilder::hasDefault()
+            ->add('foo')
+            ->addAllIf(['foo', 'bar'], fn() => false)
+            ->build();
+        $expected = ['default', 'foo'];
+
+        $this->assertSame($expected, $actual);
+    }
+
+}

--- a/test/CsvActiveProfilesParserTest.php
+++ b/test/CsvActiveProfilesParserTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Cspray\AnnotatedContainer;
+
+use PHPUnit\Framework\TestCase;
+
+class CsvActiveProfilesParserTest extends TestCase {
+
+    private function getSubject() : CsvActiveProfilesParser {
+        return new CsvActiveProfilesParser();
+    }
+
+    public function testEmptyStringThrowsException() : void {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The profiles to parse cannot be an empty string.');
+        $this->getSubject()->parse('');
+    }
+
+    public function testStringWithoutCommaReturnsCorrectArray() : void {
+        $this->assertSame(['foo'], $this->getSubject()->parse('foo'));
+    }
+
+    public function testStringWithCommaReturnsCorrectArray() : void {
+        $this->assertSame(['foo', 'bar', 'baz'], $this->getSubject()->parse('foo,bar,baz'));
+    }
+
+    public function testTrimsSpaceFromListItems() : void {
+        $this->assertSame(['foo', 'qux', 'quz'], $this->getSubject()->parse('foo, qux ,   quz    '));
+    }
+
+    public function testEmptyProfilesIgnored() : void {
+        $this->assertSame(['foo', 'bar'], $this->getSubject()->parse('foo,,bar'));
+    }
+
+    public function testNonEmptyStringResultsEmptyArrayThrowsException() : void {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("The profile string ',,' results in no valid profiles.");
+        $this->getSubject()->parse(',,');
+    }
+
+}


### PR DESCRIPTION
Adds an ActiveProfilesBuilder with a fluent API to create a list of
active profiles following the conventions laid out by Annotated
Container. It allows for conditionally adding profiles in addition to
the 'default' profile. The expected use case for this construct is when
you're programatically creating your list of active profiles.

Also adds an ActiveProfilesParser and implementation that parses a CSV
list of active profiles. For example, the string 'default,dev,local'
would result in an array of ['default', 'dev', 'local']. The intended
use case for this construct is when you have the profiles set as a
string in an environment variable or some other hard-coded
configuration.