### PR TITLE
Add third-party services first

### DIFF
--- a/fixture_src/Fixtures.php
+++ b/fixture_src/Fixtures.php
@@ -160,4 +160,8 @@ final class Fixtures {
         return new ConfigurationInjectContainerServiceFixture();
     }
 
+    public static function thirdPartyDelegatedServices() : ThirdPartyDelegatedServicesFixture {
+        return new ThirdPartyDelegatedServicesFixture();
+    }
+
 }

--- a/fixture_src/ThirdPartyDelegatedServices/LoggerFactory.php
+++ b/fixture_src/ThirdPartyDelegatedServices/LoggerFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Cspray\AnnotatedContainerFixture\ThirdPartyDelegatedServices;
+
+use Cspray\AnnotatedContainer\Attribute\ServiceDelegate;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+class LoggerFactory {
+
+    #[ServiceDelegate]
+    public function create() : LoggerInterface {
+        return new NullLogger();
+    }
+
+}

--- a/fixture_src/ThirdPartyDelegatedServicesFixture.php
+++ b/fixture_src/ThirdPartyDelegatedServicesFixture.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Cspray\AnnotatedContainerFixture;
+
+use Cspray\AnnotatedContainerFixture\ThirdPartyDelegatedServices\LoggerFactory;
+use Cspray\Typiphy\ObjectType;
+use Psr\Log\LoggerInterface;
+use function Cspray\Typiphy\objectType;
+
+final class ThirdPartyDelegatedServicesFixture implements Fixture {
+
+    public function getPath() : string {
+        return __DIR__ . '/ThirdPartyDelegatedServices';
+    }
+
+    public function loggerFactory() : ObjectType {
+        return objectType(LoggerFactory::class);
+    }
+}

--- a/src/AnnotatedTargetContainerDefinitionCompiler.php
+++ b/src/AnnotatedTargetContainerDefinitionCompiler.php
@@ -73,12 +73,12 @@ final class AnnotatedTargetContainerDefinitionCompiler implements ContainerDefin
 
         $containerDefinitionBuilder = ContainerDefinitionBuilder::newDefinition();
         $consumer = $this->parse($containerDefinitionCompileOptions, $logger);
-        $containerDefinitionBuilder = $this->addAnnotatedDefinitions($containerDefinitionBuilder, $consumer, $logger);
         $containerDefinitionBuilder = $this->addThirdPartyServices(
             $containerDefinitionCompileOptions,
             $containerDefinitionBuilder,
             $logger
         );
+        $containerDefinitionBuilder = $this->addAnnotatedDefinitions($containerDefinitionBuilder, $consumer, $logger);
         $containerDefinitionBuilder = $this->addAliasDefinitions($containerDefinitionBuilder, $logger);
 
         $logger->info('Annotated Container compiling finished.');

--- a/test/AnnotatedTargetContainerDefinitionCompilerTest.php
+++ b/test/AnnotatedTargetContainerDefinitionCompilerTest.php
@@ -471,7 +471,7 @@ class AnnotatedTargetContainerDefinitionCompilerTest extends TestCase {
         );
     }
 
-    public function testImplementServiceDelegateNotServiceThrowsException() : void {
+    public function testServiceDelegateNotServiceThrowsException() : void {
         $message = sprintf(
             'The #[ServiceDelegate] Attribute on %s::create declares a type, %s, that is not a service.',
             LogicalErrorApps\ServiceDelegateNotService\ServiceFactory::class,

--- a/test/AnnotatedTargetContainerDefinitionCompilerTests/ThirdPartyDelegatedServicesTest.php
+++ b/test/AnnotatedTargetContainerDefinitionCompilerTests/ThirdPartyDelegatedServicesTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Cspray\AnnotatedContainer\AnnotatedTargetContainerDefinitionCompilerTests;
+
+use Cspray\AnnotatedContainer\AnnotatedTargetContainerDefinitionCompilerTests\DataProviderExpects\ExpectedServiceDelegate;
+use Cspray\AnnotatedContainer\AnnotatedTargetContainerDefinitionCompilerTests\DataProviderExpects\ExpectedServiceIsAbstract;
+use Cspray\AnnotatedContainer\AnnotatedTargetContainerDefinitionCompilerTests\DataProviderExpects\ExpectedServiceIsConcrete;
+use Cspray\AnnotatedContainer\AnnotatedTargetContainerDefinitionCompilerTests\DataProviderExpects\ExpectedServiceIsPrimary;
+use Cspray\AnnotatedContainer\AnnotatedTargetContainerDefinitionCompilerTests\DataProviderExpects\ExpectedServiceName;
+use Cspray\AnnotatedContainer\AnnotatedTargetContainerDefinitionCompilerTests\DataProviderExpects\ExpectedServiceProfiles;
+use Cspray\AnnotatedContainer\AnnotatedTargetContainerDefinitionCompilerTests\DataProviderExpects\ExpectedServiceType;
+use Cspray\AnnotatedContainer\AnnotatedTargetContainerDefinitionCompilerTests\HasTestsTrait\HasNoAliasDefinitionsTrait;
+use Cspray\AnnotatedContainer\AnnotatedTargetContainerDefinitionCompilerTests\HasTestsTrait\HasNoConfigurationDefinitionsTrait;
+use Cspray\AnnotatedContainer\AnnotatedTargetContainerDefinitionCompilerTests\HasTestsTrait\HasNoInjectDefinitionsTrait;
+use Cspray\AnnotatedContainer\AnnotatedTargetContainerDefinitionCompilerTests\HasTestsTrait\HasNoServicePrepareDefinitionsTrait;
+use Cspray\AnnotatedContainer\AnnotatedTargetContainerDefinitionCompilerTests\HasTestsTrait\HasServiceDefinitionTestsTrait;
+use Cspray\AnnotatedContainer\AnnotatedTargetContainerDefinitionCompilerTests\HasTestsTrait\HasServiceDelegateDefinitionTestsTrait;
+use Cspray\AnnotatedContainer\CallableContainerDefinitionBuilderContextConsumer;
+use Cspray\AnnotatedContainer\ContainerDefinitionBuilderContext;
+use Cspray\AnnotatedContainer\ContainerDefinitionBuilderContextConsumer;
+use Cspray\AnnotatedContainerFixture\Fixture;
+use Cspray\AnnotatedContainerFixture\Fixtures;
+use Cspray\AnnotatedContainerFixture\ThirdPartyDelegatedServicesFixture;
+use Psr\Log\LoggerInterface;
+use function Cspray\AnnotatedContainer\service;
+use function Cspray\Typiphy\objectType;
+
+class ThirdPartyDelegatedServicesTest extends AnnotatedTargetContainerDefinitionCompilerTestCase {
+
+    use HasServiceDefinitionTestsTrait,
+        HasServiceDelegateDefinitionTestsTrait;
+
+    use HasNoAliasDefinitionsTrait,
+        HasNoServicePrepareDefinitionsTrait,
+        HasNoInjectDefinitionsTrait,
+        HasNoConfigurationDefinitionsTrait;
+
+    protected function getFixtures() : Fixture {
+        return new ThirdPartyDelegatedServicesFixture();
+    }
+
+    protected function getContainerDefinitionBuilderContextConsumer() : ?ContainerDefinitionBuilderContextConsumer {
+        return new CallableContainerDefinitionBuilderContextConsumer(function(ContainerDefinitionBuilderContext $context) {
+            service($context, objectType(LoggerInterface::class));
+        });
+    }
+
+    protected function serviceTypeProvider() : array {
+        return [
+            [new ExpectedServiceType(objectType(LoggerInterface::class))]
+        ];
+    }
+
+    protected function serviceNameProvider() : array {
+        return [
+            [new ExpectedServiceName(objectType(LoggerInterface::class), null)]
+        ];
+    }
+
+    protected function serviceIsPrimaryProvider() : array {
+        return [
+            [new ExpectedServiceIsPrimary(objectType(LoggerInterface::class), false)]
+        ];
+    }
+
+    protected function serviceIsConcreteProvider() : array {
+        return [
+            [new ExpectedServiceIsConcrete(objectType(LoggerInterface::class), false)]
+        ];
+    }
+
+    protected function serviceIsAbstractProvider() : array {
+        return [
+            [new ExpectedServiceIsAbstract(objectType(LoggerInterface::class), true)]
+        ];
+    }
+
+    protected function serviceProfilesProvider() : array {
+        return [
+            [new ExpectedServiceProfiles(objectType(LoggerInterface::class), ['default'])]
+        ];
+    }
+
+    protected function serviceDelegateProvider() : array {
+        return [
+            [new ExpectedServiceDelegate(
+                objectType(LoggerInterface::class),
+                Fixtures::thirdPartyDelegatedServices()->loggerFactory(),
+                'create'
+            )]
+        ];
+    }
+}

--- a/test/Cli/Command/BuildCommandTest.php
+++ b/test/Cli/Command/BuildCommandTest.php
@@ -246,11 +246,11 @@ XML;
 
         self::assertCount(2, $containerDefinition->getServiceDefinitions());
         self::assertSame(
-            Fixtures::thirdPartyServices()->fooInterface(),
+            Fixtures::thirdPartyServices()->fooImplementation(),
             $containerDefinition->getServiceDefinitions()[0]->getType()
         );
         self::assertSame(
-            Fixtures::thirdPartyServices()->fooImplementation(),
+            Fixtures::thirdPartyServices()->fooInterface(),
             $containerDefinition->getServiceDefinitions()[1]->getType()
         );
     }


### PR DESCRIPTION
Previously we were running any ContainerDefinitionBuilderContextConsumer
was being ran _after_ we added all the definitions from parsed
Attributes. However, that could result in a situation where a service is
provided by the consumer but then a service delegate or service
preparet that is annotated would fail because the corresponding service
hadn't been added yet. This change moves the addition of third-party
services to happen _first_, before the annotated definitions, ensuring
that any service delegates/prepares properly recognize that there is a
service.

Fixes #192