### PR TITLE
Exclude profile for Bootstrap logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v.1.4.0](https://github.com/cspray/annotated-container/tree/v1.4.0) - 2022-08-10
+## [v.1.4.0](https://github.com/cspray/annotated-container/tree/v1.4.0) - 2022-08-11
 
 ### Added
 
 - Added extensive logging to all compiler and container factory operations.
+- Added ability to define a stdout or file logger when using the Bootstrap functionality.
+- Added ability to define a set of profiles that should be excluded from logging when using the Bootstrap functionality.
 
 ### Fixed
 

--- a/annotated-container.xsd
+++ b/annotated-container.xsd
@@ -67,6 +67,7 @@
     <xs:all>
       <xs:element name="file" type="xs:token" minOccurs="0" maxOccurs="1" />
       <xs:element name="stdout" type="stdoutType" minOccurs="0" maxOccurs="1" />
+      <xs:element name="exclude" type="excludeType" minOccurs="0" maxOccurs="1" />
     </xs:all>
   </xs:complexType>
 
@@ -74,6 +75,12 @@
     <xs:simpleContent>
       <xs:extension base="xs:string" />
     </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="excludeType">
+    <xs:sequence>
+      <xs:element name="profile" type="xs:token" minOccurs="1" maxOccurs="unbounded" />
+    </xs:sequence>
   </xs:complexType>
 
 </xs:schema>

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -35,8 +35,9 @@ final class Bootstrap {
             $compileOptions = $compileOptions->withContainerDefinitionBuilderContextConsumer($containerDefinitionConsumer);
         }
 
+        $profilesAllowLogging = count(array_intersect($profiles, $configuration->getLoggingExcludedProfiles())) === 0;
         $logger = $configuration->getLogger();
-        if ($logger !== null) {
+        if ($logger !== null && $profilesAllowLogging) {
             $compileOptions = $compileOptions->withLogger($logger);
         }
 
@@ -54,7 +55,7 @@ final class Bootstrap {
         }
 
         $logger = $configuration->getLogger();
-        if ($logger !== null) {
+        if ($logger !== null && $profilesAllowLogging) {
             $factoryOptions = $factoryOptions->withLogger($logger);
         }
 

--- a/src/BootstrappingConfiguration.php
+++ b/src/BootstrappingConfiguration.php
@@ -23,4 +23,6 @@ interface BootstrappingConfiguration {
     public function getParameterStores() : array;
 
     public function getLogger() : ?LoggerInterface;
+
+    public function getLoggingExcludedProfiles() : array;
 }

--- a/src/XmlBootstrappingConfiguration.php
+++ b/src/XmlBootstrappingConfiguration.php
@@ -25,6 +25,7 @@ final class XmlBootstrappingConfiguration implements BootstrappingConfiguration 
     private readonly ?ContainerDefinitionBuilderContextConsumer $contextConsumer;
     private readonly ?string $cacheDir;
     private readonly ?LoggerInterface $logger;
+    private readonly array $excludedProfiles;
 
     /**
      * @var list<ParameterStore>
@@ -125,11 +126,21 @@ final class XmlBootstrappingConfiguration implements BootstrappingConfiguration 
                 $logger = new StdoutLogger($dateTimeProvider);
             }
 
+            $excludedProfilesNodes = $xpath->query('/ac:annotatedContainer/ac:logging/ac:exclude/ac:profile/text()');
+            $excludedProfiles = [];
+
+            if ($excludedProfilesNodes instanceof DOMNodeList) {
+                foreach ($excludedProfilesNodes as $node) {
+                    $excludedProfiles[] = $node->nodeValue;
+                }
+            }
+
             $this->directories = $scanDirectories;
             $this->contextConsumer = $contextConsumer;
             $this->cacheDir = $cache;
             $this->parameterStores = $parameterStores;
             $this->logger = $logger;
+            $this->excludedProfiles = $excludedProfiles;
         } finally {
             libxml_clear_errors();
             libxml_use_internal_errors(false);
@@ -158,5 +169,9 @@ final class XmlBootstrappingConfiguration implements BootstrappingConfiguration 
 
     public function getLogger() : ?LoggerInterface {
         return $this->logger;
+    }
+
+    public function getLoggingExcludedProfiles() : array {
+        return $this->excludedProfiles;
     }
 }

--- a/test/BootstrapTest.php
+++ b/test/BootstrapTest.php
@@ -223,4 +223,33 @@ XML;
         );
     }
 
+    public function testBootstrapWithLoggingProfileExcluded() : void {
+        $directoryResolver = new FixtureBootstrappingDirectoryResolver();
+
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8" ?>
+<annotatedContainer xmlns="https://annotated-container.cspray.io/schema/annotated-container.xsd">
+    <scanDirectories>
+        <source>
+            <dir>SingleConcreteService</dir>
+        </source>
+    </scanDirectories>
+    <logging>
+      <file>annotated-container.log</file>
+      <exclude><profile>test</profile></exclude>
+    </logging>
+</annotatedContainer>
+XML;
+
+        VirtualFilesystem::newFile('annotated-container.xml')
+            ->withContent($xml)
+            ->at($this->vfs);
+
+        (new Bootstrap(directoryResolver: $directoryResolver))->bootstrapContainer(['default', 'test']);
+
+        self::assertFileExists('vfs://root/annotated-container.log');
+        $logContents = file_get_contents('vfs://root/annotated-container.log');
+        self::assertSame('', $logContents);
+    }
+
 }


### PR DESCRIPTION
Logging what happens during tests can be very noisy. Introduces a
mechanism for excluding a profile from logging for this type of
scenario.

Fixes #198